### PR TITLE
fix. #30: removing unique constraint for user in refresh token model …

### DIFF
--- a/Examples/Tests/NetCore5.0/BasicAuthTests.cs
+++ b/Examples/Tests/NetCore5.0/BasicAuthTests.cs
@@ -49,5 +49,16 @@ namespace Tests.NetCore5._0
             var (response, _) = await LoginAsync(Login, "123");
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
+
+        [Fact]
+        public async Task TwoSuccessfulLoginsInARow_ReturnsTokens()
+        {
+            var (_, firstAuthModel) = await LoginAsync(Login, Password);
+            var (_, secondAuthModel) = await LoginAsync(Login, Password);
+
+            Assert.False(string.IsNullOrWhiteSpace(firstAuthModel.AccessToken.Value));
+            Assert.False(string.IsNullOrWhiteSpace(secondAuthModel.AccessToken.Value));
+            Assert.NotEqual(firstAuthModel.RefreshToken.Value, secondAuthModel.RefreshToken.Value);
+        }
     }
 }

--- a/JwtAuthentication.Identity/JwtAuthentication.Identity.csproj
+++ b/JwtAuthentication.Identity/JwtAuthentication.Identity.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <PackageId>TourmalineCore.AspNetCore.JwtAuthentication.Identity</PackageId>
-    <Version>0.0.4-alpha</Version>
+    <Version>0.0.5-alpha</Version>
     <Authors>Nikita Medvedev, Koval Maxim</Authors>
     <Company>Tourmaline Core</Company>
     <Product>JwtAuthentication</Product>

--- a/JwtAuthentication.Identity/TourmalineDbContext.cs
+++ b/JwtAuthentication.Identity/TourmalineDbContext.cs
@@ -21,11 +21,6 @@ namespace TourmalineCore.AspNetCore.JwtAuthentication.Identity
                 modelBuilder.Model.AddEntityType(typeof(RefreshToken<TUser>));
                 modelBuilder.Entity<RefreshToken<TUser>>().HasKey(x => x.Id);
                 modelBuilder.Entity<RefreshToken<TUser>>().HasIndex(x => x.Value);
-
-                modelBuilder.Entity<RefreshToken<TUser>>()
-                    .HasOne(x => x.User)
-                    .WithOne()
-                    .HasForeignKey<RefreshToken<TUser>>(x => x.UserId);
             }
         }
     }


### PR DESCRIPTION
…+ test (it needs to run on a non-memory db)